### PR TITLE
All 3rd party actions now referenced by up-to-date SHAs

### DIFF
--- a/.github/actions/azure-apply-infra-changes/action.yml
+++ b/.github/actions/azure-apply-infra-changes/action.yml
@@ -29,7 +29,7 @@ runs:
   steps:
     - name: Determine if the specified Azure parameters file has changes
       id: changed-azure-files
-      uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46
+      uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
       with:
         files: ${{ inputs.AZURE_DIRECTORY }}/${{ inputs.AZURE_PARAMETERS_FILE }}
     

--- a/.github/actions/azure-login/action.yml
+++ b/.github/actions/azure-login/action.yml
@@ -30,6 +30,6 @@ runs:
         echo "::add-mask::$azureCreds" 
         echo "azureCreds=$azureCreds" >> $GITHUB_OUTPUT
     
-    - uses: azure/login@v2
+    - uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
       with:
         creds: ${{ steps.build-creds.outputs.azureCreds }}

--- a/.github/actions/build-and-push-pimcore-image/action.yml
+++ b/.github/actions/build-and-push-pimcore-image/action.yml
@@ -77,7 +77,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       if: inputs.NPM_BUILD == 'true'
       with:
         node-version: 20
@@ -87,7 +87,7 @@ runs:
     - name: Cache node modules
       if: inputs.NPM_BUILD == 'true'
       id: cache-npm
-      uses: actions/cache@v4
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       env:
         cache-name: cache-node-modules
       with:
@@ -141,7 +141,7 @@ runs:
       shell: bash
 
     - name: Build and push image
-      uses: docker/build-push-action@v5
+      uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
       with:
         context: .
         file: ${{ inputs.DOCKERFILE_PATH }}

--- a/.github/actions/checkout/action.yml
+++ b/.github/actions/checkout/action.yml
@@ -40,7 +40,7 @@ runs:
 
     - name: Create token for main repository if using GitHub App authentication
       id: main_token
-      uses: actions/create-github-app-token@v2
+      uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
       if: inputs.GITHUB_APP_CHECKOUT == 'true'
       with:
         app-id: ${{ inputs.GITHUB_APP_ID }}
@@ -55,7 +55,7 @@ runs:
         fi
 
     - name: Checkout .gitmodules file, if using submodules
-      uses: actions/checkout@v6
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       if: inputs.SUBMODULES == 'true'
       with:
         repository: ${{ inputs.PROJECT_REPOSITORY }}
@@ -88,7 +88,7 @@ runs:
 
     - name: Create token for project and any submodules
       id: full_token
-      uses: actions/create-github-app-token@v2
+      uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
       if: inputs.GITHUB_APP_CHECKOUT == 'true'
       with:
         app-id: ${{ inputs.GITHUB_APP_ID }}
@@ -96,7 +96,7 @@ runs:
         repositories: ${{ steps.parse_repo_names.outputs.repositories }}
 
     - name: Checkout project repo and any submodules
-      uses: actions/checkout@v6
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
         repository: ${{ inputs.PROJECT_REPOSITORY }}
         ref: ${{ inputs.PROJECT_REPOSITORY_REF }}

--- a/.github/actions/send-slack-message/action.yml
+++ b/.github/actions/send-slack-message/action.yml
@@ -14,7 +14,7 @@ runs:
   steps:
     - name: Send message 
       if: ${{ inputs.SLACK_WEBHOOK_URL != '' }}
-      uses: slackapi/slack-github-action@v2
+      uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
       with:
         webhook: ${{ inputs.SLACK_WEBHOOK_URL }}
         webhook-type: incoming-webhook

--- a/.github/actions/setup-docker/action.yml
+++ b/.github/actions/setup-docker/action.yml
@@ -15,15 +15,15 @@ runs:
   using: "composite"
   steps:
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
+      uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
 
     - name: Set up Docker Buildx
       id: buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
     - name: Log in to Container Registry ${{ inputs.CONTAINER_REGISTRY }}
       if: inputs.CONTAINER_REGISTRY != ''
-      uses: docker/login-action@v3
+      uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
       with:
         registry: ${{ inputs.CONTAINER_REGISTRY }}
         username: "${{ inputs.CONTAINER_REGISTRY_USERNAME }}"

--- a/.github/actions/setup-tools/action.yml
+++ b/.github/actions/setup-tools/action.yml
@@ -5,7 +5,7 @@ runs:
   using: "composite"
   steps:
     - name: Install jq
-      uses: dcarbone/install-jq-action@b7ef57d46ece78760b4019dbc4080a1ba2a40b45
+      uses: dcarbone/install-jq-action@b7ef57d46ece78760b4019dbc4080a1ba2a40b45 # v3.2.0
       with:
         version: "1.7"
 
@@ -45,6 +45,6 @@ runs:
         echo "version=$version" >> "$GITHUB_OUTPUT"
 
     - name: Setup PHP
-      uses: shivammathur/setup-php@v2
+      uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2.37.1
       with:
         php-version: ${{ steps.get-php-version.outputs.version }}

--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -166,14 +166,14 @@ jobs:
     steps:
       - name: Get workflow version
         id: workflow-version
-        uses: canonical/get-workflow-version-action@v1
+        uses: canonical/get-workflow-version-action@b21f2a1dad0467fd79081fa16dad4f4935fc6253 # v1.0.3
         with:
           repository-name: TorqIT/pimcore-github-actions-workflows
           file-name: ci-docker.yml
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Checkout workflow repository to use composite actions
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: TorqIT/pimcore-github-actions-workflows
           ref: ${{ steps.workflow-version.outputs.sha }}
@@ -204,14 +204,14 @@ jobs:
     steps:
       - name: Get workflow version
         id: workflow-version
-        uses: canonical/get-workflow-version-action@v1
+        uses: canonical/get-workflow-version-action@b21f2a1dad0467fd79081fa16dad4f4935fc6253 # v1.0.3
         with:
           repository-name: TorqIT/pimcore-github-actions-workflows
           file-name: ci-docker.yml
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Checkout workflow repository to use composite actions
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: TorqIT/pimcore-github-actions-workflows
           ref: ${{ steps.workflow-version.outputs.sha }}
@@ -256,14 +256,14 @@ jobs:
     steps:
       - name: Get workflow version
         id: workflow-version
-        uses: canonical/get-workflow-version-action@v1
+        uses: canonical/get-workflow-version-action@b21f2a1dad0467fd79081fa16dad4f4935fc6253 # v1.0.3
         with:
           repository-name: TorqIT/pimcore-github-actions-workflows
           file-name: ci-docker.yml
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Checkout workflow repository to use composite actions
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: TorqIT/pimcore-github-actions-workflows
           ref: ${{ steps.workflow-version.outputs.sha }}
@@ -314,14 +314,14 @@ jobs:
     steps:
       - name: Get workflow version
         id: workflow-version
-        uses: canonical/get-workflow-version-action@v1
+        uses: canonical/get-workflow-version-action@b21f2a1dad0467fd79081fa16dad4f4935fc6253 # v1.0.3
         with:
           repository-name: TorqIT/pimcore-github-actions-workflows
           file-name: ci-docker.yml
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Checkout workflow repository to use composite actions
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: TorqIT/pimcore-github-actions-workflows
           ref: ${{ steps.workflow-version.outputs.sha }}
@@ -367,14 +367,14 @@ jobs:
     steps:
       - name: Get workflow version
         id: workflow-version
-        uses: canonical/get-workflow-version-action@v1
+        uses: canonical/get-workflow-version-action@b21f2a1dad0467fd79081fa16dad4f4935fc6253 # v1.0.3
         with:
           repository-name: TorqIT/pimcore-github-actions-workflows
           file-name: ci-docker.yml
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Checkout workflow repository to use composite actions
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: TorqIT/pimcore-github-actions-workflows
           ref: ${{ steps.workflow-version.outputs.sha }}

--- a/.github/workflows/deploy-to-azure-container-apps.yml
+++ b/.github/workflows/deploy-to-azure-container-apps.yml
@@ -253,7 +253,7 @@ jobs:
           echo "repository=${PROJECT_REPOSITORY#*/}" >> "$GITHUB_OUTPUT"
 
       - name: Create token from GitHub App
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         if: ${{ inputs.GITHUB_APP_CHECKOUT }}
         id: create_token
         with:
@@ -262,7 +262,7 @@ jobs:
           repositories: ${{ steps.parse_github_app_repository.outputs.repository }}
 
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: ${{ inputs.PROJECT_REPOSITORY }}
           ref: ${{ inputs.PROJECT_REPOSITORY_REF }}
@@ -272,14 +272,14 @@ jobs:
 
       - name: Get workflow version
         id: workflow-version
-        uses: canonical/get-workflow-version-action@v1
+        uses: canonical/get-workflow-version-action@b21f2a1dad0467fd79081fa16dad4f4935fc6253 # v1.0.3
         with:
           repository-name: TorqIT/pimcore-github-actions-workflows
           file-name: deploy-to-azure-container-apps.yml
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Checkout workflow repository to use composite actions
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: TorqIT/pimcore-github-actions-workflows
           ref: ${{ steps.workflow-version.outputs.sha }}
@@ -436,7 +436,7 @@ jobs:
           echo "repository=${PROJECT_REPOSITORY#*/}" >> "$GITHUB_OUTPUT"
 
       - name: Create token from GitHub App
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         if: ${{ inputs.GITHUB_APP_CHECKOUT }}
         id: create_token
         with:
@@ -445,7 +445,7 @@ jobs:
           repositories: ${{ steps.parse_github_app_repository.outputs.repository }}
 
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: ${{ inputs.PROJECT_REPOSITORY }}
           ref: ${{ inputs.PROJECT_REPOSITORY_REF }}
@@ -454,7 +454,7 @@ jobs:
             ${{ inputs.AZURE_DIRECTORY }}/${{ vars.AZURE_PARAMETERS_FILE }}
 
       - name: Checkout workflow repository to use composite actions
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: TorqIT/pimcore-github-actions-workflows
           ref: ${{ needs.build-and-push-images.outputs.workflow-version }}
@@ -498,7 +498,7 @@ jobs:
           echo "repository=${PROJECT_REPOSITORY#*/}" >> "$GITHUB_OUTPUT"
 
       - name: Create token from GitHub App
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         if: ${{ inputs.GITHUB_APP_CHECKOUT }}
         id: create_token
         with:
@@ -507,7 +507,7 @@ jobs:
           repositories: ${{ steps.parse_github_app_repository.outputs.repository }}
 
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: ${{ inputs.PROJECT_REPOSITORY }}
           ref: ${{ inputs.PROJECT_REPOSITORY_REF }}
@@ -516,7 +516,7 @@ jobs:
           token: ${{ inputs.GITHUB_APP_CHECKOUT && steps.create_token.outputs.token || secrets.GITHUB_TOKEN }}
 
       - name: Checkout workflow repository to use composite actions
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: TorqIT/pimcore-github-actions-workflows
           ref: ${{ needs.deploy-and-run-init.outputs.workflow-version }}
@@ -560,7 +560,7 @@ jobs:
           echo "repository=${PROJECT_REPOSITORY#*/}" >> "$GITHUB_OUTPUT"
 
       - name: Create token from GitHub App
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         if: ${{ inputs.GITHUB_APP_CHECKOUT }}
         id: create_token
         with:
@@ -569,7 +569,7 @@ jobs:
           repositories: ${{ steps.parse_github_app_repository.outputs.repository }}
 
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: ${{ inputs.PROJECT_REPOSITORY }}
           ref: ${{ inputs.PROJECT_REPOSITORY_REF }}
@@ -578,7 +578,7 @@ jobs:
             ${{ inputs.AZURE_DIRECTORY }}/${{ vars.AZURE_PARAMETERS_FILE }}
 
       - name: Checkout workflow repository to use composite actions
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: TorqIT/pimcore-github-actions-workflows
           ref: ${{ needs.deploy-and-run-init.outputs.workflow-version }}
@@ -626,7 +626,7 @@ jobs:
           fi
 
       - name: Send job status to Slack
-        uses: slackapi/slack-github-action@v2
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
         if: steps.check-webhook-url.outputs.slackWebhookDefined == 'true'
         with:
           webhook: ${{ secrets.SLACK_WORKFLOW_STATUS_WEBHOOK_URL }}

--- a/.github/workflows/deploy-to-vm-docker-compose.yml
+++ b/.github/workflows/deploy-to-vm-docker-compose.yml
@@ -260,7 +260,7 @@ jobs:
 
     steps:
       - name: Create token from GitHub App
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         if: ${{ inputs.GITHUB_APP_CHECKOUT }}
         id: create_token
         with:
@@ -269,7 +269,7 @@ jobs:
           repositories: ${{ inputs.GITHUB_APP_CHECKOUT_REPOSITORIES }}
 
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           submodules: ${{ inputs.SUBMODULES }}
           fetch-depth: 0
@@ -277,14 +277,14 @@ jobs:
 
       - name: Get workflow version
         id: workflow-version
-        uses: canonical/get-workflow-version-action@v1
+        uses: canonical/get-workflow-version-action@b21f2a1dad0467fd79081fa16dad4f4935fc6253 # v1.0.3
         with:
           repository-name: TorqIT/pimcore-github-actions-workflows
           file-name: deploy-to-vm-docker-compose.yml
           github-token: ${{ secrets.CALLER_GITHUB_TOKEN }}
 
       - name: Checkout workflow repository to use composite actions
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: TorqIT/pimcore-github-actions-workflows
           ref: ${{ steps.workflow-version.outputs.sha }}
@@ -374,7 +374,7 @@ jobs:
       - build-and-push-images
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           sparse-checkout: |
             docker-compose.yaml
@@ -384,12 +384,12 @@ jobs:
           sparse-checkout-cone-mode: false
 
       - name: Install jq
-        uses: dcarbone/install-jq-action@b7ef57d46ece78760b4019dbc4080a1ba2a40b45
+        uses: dcarbone/install-jq-action@b7ef57d46ece78760b4019dbc4080a1ba2a40b45 # v3.2.0
         with:
           version: "1.7"
 
       - name: Log in to Container Registry ${{ inputs.CONTAINER_REGISTRY }}
-        uses: docker/login-action@v3
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ${{ inputs.CONTAINER_REGISTRY }}
           username: ${{ inputs.CONTAINER_REGISTRY_USERNAME }}
@@ -412,7 +412,7 @@ jobs:
 
       - name: Extract external volume names
         id: extract-volumes
-        uses: mikefarah/yq@v4.44.1
+        uses: mikefarah/yq@751d8ad57b84f1794661bc70c0afb92a22ad7b3c # v4.53.2
         with:
           cmd: >
             yq e -o=json '.volumes // {} | to_entries |
@@ -421,7 +421,7 @@ jobs:
 
       - name: Extract external network names
         id: extract-networks
-        uses: mikefarah/yq@v4.44.1
+        uses: mikefarah/yq@751d8ad57b84f1794661bc70c0afb92a22ad7b3c # v4.53.2
         with:
           cmd: >
             yq e -o=json '.networks // {} | to_entries |
@@ -601,7 +601,7 @@ jobs:
           fi
 
       - name: Send job status to Slack
-        uses: slackapi/slack-github-action@v2
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
         if: steps.check-webhook-url.outputs.slackWebhookDefined == 'true'
         with:
           webhook: ${{ secrets.SLACK_WORKFLOW_STATUS_WEBHOOK_URL }}

--- a/.github/workflows/docker-builds.yml
+++ b/.github/workflows/docker-builds.yml
@@ -118,20 +118,20 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           submodules: ${{ inputs.SUBMODULES }}
 
       - name: Get workflow version
         id: workflow-version
-        uses: canonical/get-workflow-version-action@v1
+        uses: canonical/get-workflow-version-action@b21f2a1dad0467fd79081fa16dad4f4935fc6253 # v1.0.3
         with:
           repository-name: TorqIT/pimcore-github-actions-workflows
           file-name: docker-builds.yml
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Checkout workflow repository to use composite actions
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: TorqIT/pimcore-github-actions-workflows
           ref: ${{ steps.workflow-version.outputs.sha }}

--- a/.github/workflows/job-azure-container-apps-deactivate-revisions.yml
+++ b/.github/workflows/job-azure-container-apps-deactivate-revisions.yml
@@ -66,14 +66,14 @@ jobs:
     steps:
       - name: Get workflow version
         id: workflow-version
-        uses: canonical/get-workflow-version-action@v1
+        uses: canonical/get-workflow-version-action@b21f2a1dad0467fd79081fa16dad4f4935fc6253 # v1.0.3
         with:
           repository-name: TorqIT/pimcore-github-actions-workflows
           file-name: job-azure-container-apps-deactivate-revisions.yml
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Checkout workflow repository to use composite actions
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: TorqIT/pimcore-github-actions-workflows
           ref: ${{ steps.workflow-version.outputs.sha }}
@@ -92,7 +92,7 @@ jobs:
           SUBSCRIPTION: ${{ vars.AZURE_SUBSCRIPTION_ID }}
 
       - name: Deactivate revisions that have been at 0% traffic for 12 hours
-        uses: azure/cli@v2
+        uses: azure/cli@9eb25b8360668fb0ecbafa808d40e2197b2f5f52 # v3.0.0
         with:
           inlineScript: |
             set -e

--- a/.github/workflows/job-azure-disk-backup.yml
+++ b/.github/workflows/job-azure-disk-backup.yml
@@ -66,14 +66,14 @@ jobs:
     steps:
       - name: Get workflow version
         id: workflow-version
-        uses: canonical/get-workflow-version-action@v1
+        uses: canonical/get-workflow-version-action@b21f2a1dad0467fd79081fa16dad4f4935fc6253 # v1.0.3
         with:
           repository-name: TorqIT/pimcore-github-actions-workflows
           file-name: job-azure-disk-backup.yml
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Checkout workflow repository to use composite actions
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: TorqIT/pimcore-github-actions-workflows
           ref: ${{ steps.workflow-version.outputs.sha }}
@@ -93,7 +93,7 @@ jobs:
 
       - name: Create backup
         id: backup
-        uses: azure/cli@v2
+        uses: azure/cli@9eb25b8360668fb0ecbafa808d40e2197b2f5f52 # v3.0.0
         with:
           inlineScript: |
             set -e
@@ -108,7 +108,7 @@ jobs:
 
       - name: Send job status to Slack
         if: always()
-        uses: slackapi/slack-github-action@v2
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
         with:
           webhook: ${{ secrets.SLACK_BACKUPS_WEBHOOK_URL }}
           webhook-type: incoming-webhook

--- a/.github/workflows/job-azure-file-share-backup.yml
+++ b/.github/workflows/job-azure-file-share-backup.yml
@@ -67,14 +67,14 @@ jobs:
     steps:
       - name: Get workflow version
         id: workflow-version
-        uses: canonical/get-workflow-version-action@v1
+        uses: canonical/get-workflow-version-action@b21f2a1dad0467fd79081fa16dad4f4935fc6253 # v1.0.3
         with:
           repository-name: TorqIT/pimcore-github-actions-workflows
           file-name: job-azure-file-share-backup.yml
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Checkout workflow repository to use composite actions
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: TorqIT/pimcore-github-actions-workflows
           ref: ${{ steps.workflow-version.outputs.sha }}
@@ -93,7 +93,7 @@ jobs:
           SUBSCRIPTION: ${{ vars.AZURE_SUBSCRIPTION_ID }}
 
       - name: Add temporary network rule for this runner to Storage Account firewall
-        uses: azure/cli@v2
+        uses: azure/cli@9eb25b8360668fb0ecbafa808d40e2197b2f5f52 # v3.0.0
         with:
           inlineScript: |
             set -e
@@ -116,7 +116,7 @@ jobs:
 
       - name: Remove temporary network rule from Storage Account firewall
         if: always()
-        uses: azure/cli@v2
+        uses: azure/cli@9eb25b8360668fb0ecbafa808d40e2197b2f5f52 # v3.0.0
         with:
           inlineScript: |
             set -e
@@ -128,7 +128,7 @@ jobs:
 
       - name: Send job status to Slack
         if: always()
-        uses: slackapi/slack-github-action@v2
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
         with:
           webhook: ${{ secrets.SLACK_BACKUPS_WEBHOOK_URL }}
           webhook-type: incoming-webhook

--- a/.github/workflows/job-azure-mysql-backup.yml
+++ b/.github/workflows/job-azure-mysql-backup.yml
@@ -74,14 +74,14 @@ jobs:
     steps:
       - name: Get workflow version
         id: workflow-version
-        uses: canonical/get-workflow-version-action@v1
+        uses: canonical/get-workflow-version-action@b21f2a1dad0467fd79081fa16dad4f4935fc6253 # v1.0.3
         with:
           repository-name: TorqIT/pimcore-github-actions-workflows
           file-name: job-azure-mysql-backup.yml
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Checkout workflow repository to use composite actions
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: TorqIT/pimcore-github-actions-workflows
           ref: ${{ steps.workflow-version.outputs.sha }}
@@ -100,7 +100,7 @@ jobs:
           SUBSCRIPTION: ${{ vars.AZURE_SUBSCRIPTION_ID }}
 
       - name: Add temporary network rule for this runner to database server and Storage Account firewalls
-        uses: azure/cli@v2
+        uses: azure/cli@9eb25b8360668fb0ecbafa808d40e2197b2f5f52 # v3.0.0
         with:
           inlineScript: |
             set -e
@@ -164,7 +164,7 @@ jobs:
 
       - name: Remove temporary network rule from database server firewall
         if: always()
-        uses: azure/cli@v2
+        uses: azure/cli@9eb25b8360668fb0ecbafa808d40e2197b2f5f52 # v3.0.0
         with:
           inlineScript: |
             set -e
@@ -176,7 +176,7 @@ jobs:
 
       - name: Remove temporary network rule from Storage Account firewall
         if: always()
-        uses: azure/cli@v2
+        uses: azure/cli@9eb25b8360668fb0ecbafa808d40e2197b2f5f52 # v3.0.0
         with:
           inlineScript: |
             set -e
@@ -188,7 +188,7 @@ jobs:
 
       - name: Send job status to Slack
         if: ${{ !cancelled() }}
-        uses: slackapi/slack-github-action@v2
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
         with:
           webhook: ${{ secrets.SLACK_BACKUPS_WEBHOOK_URL }}
           webhook-type: incoming-webhook

--- a/.github/workflows/job-azure-storage-sync.yml
+++ b/.github/workflows/job-azure-storage-sync.yml
@@ -94,14 +94,14 @@ jobs:
     steps:
       - name: Get workflow version
         id: workflow-version
-        uses: canonical/get-workflow-version-action@v1
+        uses: canonical/get-workflow-version-action@b21f2a1dad0467fd79081fa16dad4f4935fc6253 # v1.0.3
         with:
           repository-name: TorqIT/pimcore-github-actions-workflows
           file-name: job-azure-storage-sync.yml
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Checkout workflow repository to use composite actions
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: TorqIT/pimcore-github-actions-workflows
           ref: ${{ steps.workflow-version.outputs.sha }}
@@ -127,7 +127,7 @@ jobs:
           echo "✓ Target storage account and container validation passed"
 
       - name: Log in to Azure via Service Principal
-        uses: azure/cli@v2
+        uses: azure/cli@9eb25b8360668fb0ecbafa808d40e2197b2f5f52 # v3.0.0
         with:
           azcliversion: latest
           inlineScript: |
@@ -138,7 +138,7 @@ jobs:
             echo "Azure login successful"
 
       - name: Add temporary network rule for this runner to Storage Account firewalls
-        uses: azure/cli@v2
+        uses: azure/cli@9eb25b8360668fb0ecbafa808d40e2197b2f5f52 # v3.0.0
         with:
           inlineScript: |
             set -e
@@ -250,7 +250,7 @@ jobs:
 
       - name: Remove temporary network rule from source Storage Account firewall
         if: always()
-        uses: azure/cli@v2
+        uses: azure/cli@9eb25b8360668fb0ecbafa808d40e2197b2f5f52 # v3.0.0
         with:
           inlineScript: |
             set -e
@@ -271,7 +271,7 @@ jobs:
 
       - name: Remove temporary network rule from target Storage Account firewall
         if: always()
-        uses: azure/cli@v2
+        uses: azure/cli@9eb25b8360668fb0ecbafa808d40e2197b2f5f52 # v3.0.0
         with:
           inlineScript: |
             set -e

--- a/.github/workflows/job-azure-sync.yml
+++ b/.github/workflows/job-azure-sync.yml
@@ -196,7 +196,7 @@ jobs:
 
     steps:
       - name: Deactivate Container App revisions
-        uses: azure/cli@v2
+        uses: azure/cli@9eb25b8360668fb0ecbafa808d40e2197b2f5f52 # v3.0.0
         with:
           inlineScript: |
             set -e
@@ -322,7 +322,7 @@ jobs:
 
     steps:
       - name: Restart PHP Container App latest deactivated revision
-        uses: azure/cli@v2
+        uses: azure/cli@9eb25b8360668fb0ecbafa808d40e2197b2f5f52 # v3.0.0
         with:
           inlineScript: |
             set -e
@@ -391,14 +391,14 @@ jobs:
     steps:
       - name: Get workflow version
         id: workflow-version
-        uses: canonical/get-workflow-version-action@v1
+        uses: canonical/get-workflow-version-action@b21f2a1dad0467fd79081fa16dad4f4935fc6253 # v1.0.3
         with:
           repository-name: TorqIT/pimcore-github-actions-workflows
           file-name: job-azure-sync.yml
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Checkout workflow repository to use composite actions
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: TorqIT/pimcore-github-actions-workflows
           ref: ${{ steps.workflow-version.outputs.sha }}

--- a/.github/workflows/job-mysql-sync.yml
+++ b/.github/workflows/job-mysql-sync.yml
@@ -150,14 +150,14 @@ jobs:
     steps:
       - name: Get workflow version
         id: workflow-version
-        uses: canonical/get-workflow-version-action@v1
+        uses: canonical/get-workflow-version-action@b21f2a1dad0467fd79081fa16dad4f4935fc6253 # v1.0.3
         with:
           repository-name: TorqIT/pimcore-github-actions-workflows
           file-name: job-mysql-sync.yml
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Checkout workflow repository to use composite actions
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: TorqIT/pimcore-github-actions-workflows
           ref: ${{ steps.workflow-version.outputs.sha }}
@@ -184,7 +184,7 @@ jobs:
 
       - name: If source or target are in Azure, log in to Azure via Service Principal
         if: ${{ inputs.SOURCE_IS_IN_AZURE || inputs.TARGET_IS_IN_AZURE }}
-        uses: azure/cli@v2
+        uses: azure/cli@9eb25b8360668fb0ecbafa808d40e2197b2f5f52 # v3.0.0
         with:
           azcliversion: latest
           inlineScript: |
@@ -196,7 +196,7 @@ jobs:
 
       - name: If source is an Azure MySQL server, add temporary network rule for this runner
         if: ${{ inputs.SOURCE_IS_IN_AZURE }}
-        uses: azure/cli@v2
+        uses: azure/cli@9eb25b8360668fb0ecbafa808d40e2197b2f5f52 # v3.0.0
         with:
           inlineScript: |
             set -e
@@ -213,7 +213,7 @@ jobs:
 
       - name: If target is an Azure MySQL server, add temporary network rule for this runner
         if: ${{ inputs.TARGET_IS_IN_AZURE }}
-        uses: azure/cli@v2
+        uses: azure/cli@9eb25b8360668fb0ecbafa808d40e2197b2f5f52 # v3.0.0
         with:
           inlineScript: |
             set -e
@@ -470,7 +470,7 @@ jobs:
 
       - name: Remove temporary Azure network rule from source database server firewall
         if: ${{ always() && inputs.SOURCE_IS_IN_AZURE }}
-        uses: azure/cli@v2
+        uses: azure/cli@9eb25b8360668fb0ecbafa808d40e2197b2f5f52 # v3.0.0
         with:
           inlineScript: |
             set -e
@@ -483,7 +483,7 @@ jobs:
 
       - name: Remove temporary Azure network rule from target database server firewall
         if: ${{ always() && inputs.TARGET_IS_IN_AZURE }}
-        uses: azure/cli@v2
+        uses: azure/cli@9eb25b8360668fb0ecbafa808d40e2197b2f5f52 # v3.0.0
         with:
           inlineScript: |
             set -e

--- a/.github/workflows/meta-ci.yml
+++ b/.github/workflows/meta-ci.yml
@@ -61,6 +61,7 @@ jobs:
       DOCKER_COMPOSE_FILE: ./.github/ci/azure/docker-compose.yml
       PARAMETERS_FILE: ./.github/ci/azure/parameters.json
       SERVICE_PRINCIPAL_ID: ${{ vars.CI_SERVICE_PRINCIPAL_ID }}
+      SKIP_IF_EXISTS: false
     secrets:
       PIMCORE_ENCRYPTION_SECRET: ${{ secrets.PIMCORE_ENCRYPTION_SECRET }}
       PIMCORE_INSTANCE_IDENTIFIER: ${{ secrets.PIMCORE_INSTANCE_IDENTIFIER }}

--- a/.github/workflows/meta-ci.yml
+++ b/.github/workflows/meta-ci.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Lint files
         uses: ./.github/actions/lint

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -42,18 +42,18 @@ jobs:
       TAG: ${{ github.run_id }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Get workflow version
         id: workflow-version
-        uses: canonical/get-workflow-version-action@v1
+        uses: canonical/get-workflow-version-action@b21f2a1dad0467fd79081fa16dad4f4935fc6253 # v1.0.3
         with:
           repository-name: TorqIT/pimcore-github-actions-workflows
           file-name: run-tests.yml
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Checkout workflow repository to use composite actions
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: TorqIT/pimcore-github-actions-workflows
           ref: ${{ steps.workflow-version.outputs.sha }}


### PR DESCRIPTION
Relates to DVPS-377
Relates to DVPS-376

This PR resolves two issues with our shared workflows:
1. 3rd party actions are all now referenced by full commit SHAs rather than tags, to mitigate supply-chain attacks https://docs.github.com/en/actions/reference/security/secure-use#using-third-party-actions
2. Updates actions to latest stable versions in response to Node JS 20 deprecation https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/