### PR TITLE
More vulnerability scan result improvements

### DIFF
--- a/.github/actions/post-scan-report/action.yml
+++ b/.github/actions/post-scan-report/action.yml
@@ -136,7 +136,7 @@ runs:
                     .key,
                     (.value.severity | ascii_upcase),
                     ($versions[.key] // "unknown"),
-                    (if (.value.fixAvailable | type) == "object" then .value.fixAvailable.version else "" end),
+                    (if (.value.fixAvailable | type) == "object" then .value.fixAvailable.version else "-" end),
                     (if .value.fixAvailable == true then "auto" else "manual" end)
                   ] |
                   @tsv
@@ -153,7 +153,7 @@ runs:
                   else
                     cmd="\`npm audit fix --force --prefix $scan_dir\` _(may introduce breaking changes)_"
                   fi
-                  echo "| \`$pkg\` | $severity | \`$installed\` | \`${fix_ver:----}\` | $cmd |"
+                  echo "| \`$pkg\` | $severity | \`$installed\` | \`$fix_ver\` | $cmd |"
                 done <<< "$rows"
                 echo ""
               done

--- a/.github/actions/post-scan-report/action.yml
+++ b/.github/actions/post-scan-report/action.yml
@@ -241,7 +241,7 @@ runs:
                   sort_by(.extra.severity, .path, .start.line) |
                   .[] |
                   [
-                    (.check_id | split(".") | last),
+                    ("[" + (.check_id | split(".") | last) + "](https://semgrep.dev/r/" + .check_id + ")"),
                     .path,
                     (.start.line | tostring),
                     .extra.severity,
@@ -253,7 +253,7 @@ runs:
                   echo "| Rule | Location | Severity | Message |"
                   echo "|------|----------|----------|---------|"
                   while IFS=$'\t' read -r rule file line severity message; do
-                    echo "| \`$rule\` | \`$file:$line\` | $severity | $message |"
+                    echo "| $rule | \`$file:$line\` | $severity | $message |"
                   done <<< "$rows"
                   echo ""
                 else

--- a/.github/actions/post-scan-report/action.yml
+++ b/.github/actions/post-scan-report/action.yml
@@ -176,7 +176,14 @@ runs:
                   echo "| Package | Severity | Installed | Fix ≥ | Advisory | Command |"
                   echo "|---------|----------|-----------|-------|----------|---------|"
                   while IFS=$'\t' read -r pkg severity current_ver affected advisory; do
-                    fix_ver=$(echo "$affected" | grep -oE '<[0-9]+\.[0-9]+(\.[0-9]+)?' | tr -d '<' | sort -V | head -1 || echo "")
+                    fix_ver=$(echo "$affected" | grep -oE '<[0-9]+\.[0-9]+(\.[0-9]+)?' | tr -d '<' | sort -V | head -1)
+                    if [ -z "$fix_ver" ]; then
+                      incl=$(echo "$affected" | grep -oE '<=[0-9]+\.[0-9]+\.[0-9]+' | sed 's/^<=//' | sort -V | head -1)
+                      if [ -n "$incl" ]; then
+                        p=$(echo "$incl" | cut -d. -f3)
+                        fix_ver="$(echo "$incl" | cut -d. -f1-2).$((p + 1))"
+                      fi
+                    fi
                     [ -z "$fix_ver" ] && fix_ver="$affected"
                     echo "| \`$pkg\` | $severity | \`$current_ver\` | \`$fix_ver\` | $advisory | \`composer update $pkg\` |"
                   done <<< "$rows"

--- a/.github/actions/post-scan-report/action.yml
+++ b/.github/actions/post-scan-report/action.yml
@@ -141,7 +141,8 @@ runs:
                        ([(.value.via // [] | .[] | select(type == "object") | .range // ""), (.value.range // "")] |
                         join(" ") | [scan("<[0-9][^\\s]*")] | map(ltrimstr("<")) | first) // "-"
                      end),
-                    (if (.value.fixAvailable | type) == "object" and .value.fixAvailable.isSemVerMajor then "force" else "auto" end)
+                    (if (.value.fixAvailable | type) == "object" and .value.fixAvailable.isSemVerMajor then "force" else "auto" end),
+                    (([.value.via // [] | .[] | select(type == "object") | .url // ""] | map(select(. != "")) | first) // "-")
                   ] |
                   @tsv
                 ' "$json_file" 2>/dev/null || echo "")
@@ -149,15 +150,21 @@ runs:
                 found_any=true
                 echo "**\`$scan_dir\`**"
                 echo ""
-                echo "| Package | Severity | Installed | Fix ≥ | Command |"
-                echo "|---------|----------|-----------|-------|---------|"
-                while IFS=$'\t' read -r pkg severity installed fix_ver fix_type; do
-                  if [ "$fix_type" = "auto" ]; then
-                    cmd="\`npm audit fix --prefix $scan_dir\`"
-                  else
+                echo "| Package | Severity | Installed | Fix ≥ | Advisory | Command |"
+                echo "|---------|----------|-----------|-------|----------|---------|"
+                while IFS=$'\t' read -r pkg severity installed fix_ver fix_type advisory_url; do
+                  if [ "$fix_type" = "force" ]; then
                     cmd="\`npm audit fix --force --prefix $scan_dir\` _(may introduce breaking changes)_"
+                  else
+                    cmd="\`npm audit fix --prefix $scan_dir\`"
                   fi
-                  echo "| \`$pkg\` | $severity | \`$installed\` | \`$fix_ver\` | $cmd |"
+                  if [ "$advisory_url" != "-" ] && [ -n "$advisory_url" ]; then
+                    advisory_id=$(basename "$advisory_url")
+                    advisory_col="[$advisory_id]($advisory_url)"
+                  else
+                    advisory_col="-"
+                  fi
+                  echo "| \`$pkg\` | $severity | \`$installed\` | \`$fix_ver\` | $advisory_col | $cmd |"
                 done <<< "$rows"
                 echo ""
               done
@@ -183,13 +190,13 @@ runs:
                   ($versions[$pkg] // "unknown") as $current_ver |
                   .value[] |
                   select(.ignored != true and (.severity == "high" or .severity == "critical")) |
-                  [$pkg, (.severity | ascii_upcase), $current_ver, (.affectedVersions // ""), (.advisoryId // "")] |
+                  [$pkg, (.severity | ascii_upcase), $current_ver, (.affectedVersions // ""), (.advisoryId // "-"), (.link // "-"), (.cve // "-")] |
                   @tsv
                 ' ./scan-results/composer-audit.json 2>/dev/null || echo "")
                 if [ -n "$rows" ]; then
                   echo "| Package | Severity | Installed | Fix ≥ | Advisory | Command |"
                   echo "|---------|----------|-----------|-------|----------|---------|"
-                  while IFS=$'\t' read -r pkg severity current_ver affected advisory; do
+                  while IFS=$'\t' read -r pkg severity current_ver affected advisory link cve; do
                     fix_ver=$(echo "$affected" | grep -oE '<[0-9]+\.[0-9]+(\.[0-9]+)?' | tr -d '<' | sort -V | head -1 || true)
                     if [ -z "$fix_ver" ]; then
                       incl=$(echo "$affected" | grep -oE '<=[0-9]+\.[0-9]+\.[0-9]+' | sed 's/^<=//' | sort -V | head -1 || true)
@@ -199,7 +206,15 @@ runs:
                       fi
                     fi
                     [ -z "$fix_ver" ] && fix_ver="$affected"
-                    echo "| \`$pkg\` | $severity | \`$current_ver\` | \`$fix_ver\` | $advisory | \`composer update $pkg\` |"
+                    if [ "$link" != "-" ] && [ -n "$link" ]; then
+                      advisory_col="[$advisory]($link)"
+                    else
+                      advisory_col="$advisory"
+                    fi
+                    if [ "$cve" != "-" ] && [ -n "$cve" ]; then
+                      advisory_col="$advisory_col / [$cve](https://nvd.nist.gov/vuln/detail/$cve)"
+                    fi
+                    echo "| \`$pkg\` | $severity | \`$current_ver\` | \`$fix_ver\` | $advisory_col | \`composer update $pkg\` |"
                   done <<< "$rows"
                   echo ""
                 else

--- a/.github/actions/post-scan-report/action.yml
+++ b/.github/actions/post-scan-report/action.yml
@@ -161,11 +161,12 @@ runs:
               echo "<summary><strong>Composer audit</strong></summary>"
               echo ""
               if [ -f "./scan-results/composer-audit.json" ]; then
-                rows=$(jq -r '
-                  (.packages // []) as $pkgs |
+                pkgs_json=$(cat "./scan-results/composer-packages.json" 2>/dev/null || echo '[]')
+                rows=$(jq -r --argjson pkgs "$pkgs_json" '
+                  ($pkgs | map({(.name): .version}) | add // {}) as $versions |
                   .advisories // {} | to_entries[] |
                   .key as $pkg |
-                  ($pkgs | map(select(.name == $pkg)) | .[0].version // "unknown") as $current_ver |
+                  ($versions[$pkg] // "unknown") as $current_ver |
                   .value[] |
                   select(.ignored != true and (.severity == "high" or .severity == "critical")) |
                   [$pkg, (.severity | ascii_upcase), $current_ver, (.affectedVersions // ""), (.advisoryId // "")] |

--- a/.github/actions/post-scan-report/action.yml
+++ b/.github/actions/post-scan-report/action.yml
@@ -198,8 +198,36 @@ runs:
               echo "<details>"
               echo "<summary><strong>Semgrep SAST</strong></summary>"
               echo ""
-              echo "Code-level findings require manual review — refer to the [action logs]($LOGS_URL) for the flagged patterns and file locations."
-              echo ""
+              if [ -f "./scan-results/semgrep.json" ]; then
+                rows=$(jq -r '
+                  .results // [] |
+                  map(select(.extra.severity == "ERROR" or .extra.severity == "WARNING")) |
+                  sort_by(.extra.severity, .path, .start.line) |
+                  .[] |
+                  [
+                    (.check_id | split(".") | last),
+                    .path,
+                    (.start.line | tostring),
+                    .extra.severity,
+                    (.extra.message | gsub("[\n\r\t]"; " ") | .[0:120])
+                  ] |
+                  @tsv
+                ' ./scan-results/semgrep.json 2>/dev/null || echo "")
+                if [ -n "$rows" ]; then
+                  echo "| Rule | Location | Severity | Message |"
+                  echo "|------|----------|----------|---------|"
+                  while IFS=$'\t' read -r rule file line severity message; do
+                    echo "| \`$rule\` | \`$file:$line\` | $severity | $message |"
+                  done <<< "$rows"
+                  echo ""
+                else
+                  echo "Could not parse detailed results — refer to the [action logs]($LOGS_URL) for the flagged patterns and file locations."
+                  echo ""
+                fi
+              else
+                echo "Could not parse detailed results — refer to the [action logs]($LOGS_URL) for the flagged patterns and file locations."
+                echo ""
+              fi
               echo "</details>"
               echo ""
             fi

--- a/.github/actions/post-scan-report/action.yml
+++ b/.github/actions/post-scan-report/action.yml
@@ -219,7 +219,7 @@ runs:
                   echo ""
                 else
                   if grep -q "affected by security advisories" ./scan-results/composer-audit.txt 2>/dev/null; then
-                    echo "Composer install was blocked — one or more required packages are affected by security advisories. Update \`pimcore/pimcore\` and its dependencies, or refer to the [action logs]($LOGS_URL) for the full list of advisory IDs."
+                    echo "Composer install was blocked — one or more required packages are affected by security advisories. Refer to the [action logs]($LOGS_URL) for the full list of advisory IDs."
                   else
                     echo "No HIGH or CRITICAL advisories found — refer to the [action logs]($LOGS_URL) for lower-severity findings."
                   fi
@@ -227,7 +227,7 @@ runs:
                 fi
               else
                 if grep -q "affected by security advisories" ./scan-results/composer-audit.txt 2>/dev/null; then
-                  echo "Composer install was blocked — one or more required packages are affected by security advisories. Update \`pimcore/pimcore\` and its dependencies, or refer to the [action logs]($LOGS_URL) for the full list of advisory IDs."
+                  echo "Composer install was blocked — one or more required packages are affected by security advisories. Refer to the [action logs]($LOGS_URL) for the full list of advisory IDs."
                 else
                   echo "Could not parse detailed results — refer to the [action logs]($LOGS_URL)."
                 fi

--- a/.github/actions/post-scan-report/action.yml
+++ b/.github/actions/post-scan-report/action.yml
@@ -136,7 +136,9 @@ runs:
                     .key,
                     (.value.severity | ascii_upcase),
                     ($versions[.key] // "unknown"),
-                    (if (.value.fixAvailable | type) == "object" then .value.fixAvailable.version else "-" end),
+                    (if (.value.fixAvailable | type) == "object" then .value.fixAvailable.version
+                     else ([.value.range // "" | scan("<[0-9][^\\s]*")] | map(ltrimstr("<")) | first) // "-"
+                     end),
                     (if .value.fixAvailable == true then "auto" else "manual" end)
                   ] |
                   @tsv

--- a/.github/actions/post-scan-report/action.yml
+++ b/.github/actions/post-scan-report/action.yml
@@ -137,9 +137,11 @@ runs:
                     (.value.severity | ascii_upcase),
                     ($versions[.key] // "unknown"),
                     (if (.value.fixAvailable | type) == "object" then .value.fixAvailable.version
-                     else ([.value.range // "" | scan("<[0-9][^\\s]*")] | map(ltrimstr("<")) | first) // "-"
+                     else
+                       ([(.value.via // [] | .[] | select(type == "object") | .range // ""), (.value.range // "")] |
+                        join(" ") | [scan("<[0-9][^\\s]*")] | map(ltrimstr("<")) | first) // "-"
                      end),
-                    (if .value.fixAvailable == true then "auto" else "manual" end)
+                    (if (.value.fixAvailable | type) == "object" and .value.fixAvailable.isSemVerMajor then "force" else "auto" end)
                   ] |
                   @tsv
                 ' "$json_file" 2>/dev/null || echo "")

--- a/.github/actions/post-scan-report/action.yml
+++ b/.github/actions/post-scan-report/action.yml
@@ -175,7 +175,7 @@ runs:
                   echo "| Package | Severity | Installed | Fix ≥ | Advisory | Command |"
                   echo "|---------|----------|-----------|-------|----------|---------|"
                   while IFS=$'\t' read -r pkg severity current_ver affected advisory; do
-                    fix_ver=$(echo "$affected" | grep -oE '<[0-9]+\.[0-9]+(\.[0-9]+)?' | tr -d '<' | sort -V | head -1)
+                    fix_ver=$(echo "$affected" | grep -oE '<[0-9]+\.[0-9]+(\.[0-9]+)?' | tr -d '<' | sort -V | head -1 || echo "")
                     [ -z "$fix_ver" ] && fix_ver="$affected"
                     echo "| \`$pkg\` | $severity | \`$current_ver\` | \`$fix_ver\` | $advisory | \`composer update $pkg\` |"
                   done <<< "$rows"

--- a/.github/actions/post-scan-report/action.yml
+++ b/.github/actions/post-scan-report/action.yml
@@ -186,9 +186,9 @@ runs:
                   echo "| Package | Severity | Installed | Fix ≥ | Advisory | Command |"
                   echo "|---------|----------|-----------|-------|----------|---------|"
                   while IFS=$'\t' read -r pkg severity current_ver affected advisory; do
-                    fix_ver=$(echo "$affected" | grep -oE '<[0-9]+\.[0-9]+(\.[0-9]+)?' | tr -d '<' | sort -V | head -1)
+                    fix_ver=$(echo "$affected" | grep -oE '<[0-9]+\.[0-9]+(\.[0-9]+)?' | tr -d '<' | sort -V | head -1 || true)
                     if [ -z "$fix_ver" ]; then
-                      incl=$(echo "$affected" | grep -oE '<=[0-9]+\.[0-9]+\.[0-9]+' | sed 's/^<=//' | sort -V | head -1)
+                      incl=$(echo "$affected" | grep -oE '<=[0-9]+\.[0-9]+\.[0-9]+' | sed 's/^<=//' | sort -V | head -1 || true)
                       if [ -n "$incl" ]; then
                         p=$(echo "$incl" | cut -d. -f3)
                         fix_ver="$(echo "$incl" | cut -d. -f1-2).$((p + 1))"

--- a/.github/actions/post-scan-report/action.yml
+++ b/.github/actions/post-scan-report/action.yml
@@ -218,11 +218,19 @@ runs:
                   done <<< "$rows"
                   echo ""
                 else
-                  echo "No HIGH or CRITICAL advisories found — refer to the [action logs]($LOGS_URL) for lower-severity findings."
+                  if grep -q "affected by security advisories" ./scan-results/composer-audit.txt 2>/dev/null; then
+                    echo "Composer install was blocked — one or more required packages are affected by security advisories. Update \`pimcore/pimcore\` and its dependencies, or refer to the [action logs]($LOGS_URL) for the full list of advisory IDs."
+                  else
+                    echo "No HIGH or CRITICAL advisories found — refer to the [action logs]($LOGS_URL) for lower-severity findings."
+                  fi
                   echo ""
                 fi
               else
-                echo "Could not parse detailed results — refer to the [action logs]($LOGS_URL)."
+                if grep -q "affected by security advisories" ./scan-results/composer-audit.txt 2>/dev/null; then
+                  echo "Composer install was blocked — one or more required packages are affected by security advisories. Update \`pimcore/pimcore\` and its dependencies, or refer to the [action logs]($LOGS_URL) for the full list of advisory IDs."
+                else
+                  echo "Could not parse detailed results — refer to the [action logs]($LOGS_URL)."
+                fi
                 echo ""
               fi
               echo "</details>"

--- a/.github/actions/post-scan-report/action.yml
+++ b/.github/actions/post-scan-report/action.yml
@@ -126,24 +126,34 @@ runs:
               for json_file in ./scan-results/npm-raw-*.json; do
                 [ -f "$json_file" ] || continue
                 scan_dir=$(jq -r '._scannedDir // "."' "$json_file" 2>/dev/null || echo ".")
-                rows=$(jq -r '
+                dir_slug=$(echo "$scan_dir" | sed 's|^\./||;s|/|__|g')
+                pkgs_json=$(cat "./scan-results/npm-packages-${dir_slug:-root}.json" 2>/dev/null || echo '[]')
+                rows=$(jq -r --argjson pkgs "$pkgs_json" '
+                  ($pkgs | map({(.name): .version}) | add // {}) as $versions |
                   (.vulnerabilities // {}) | to_entries[] |
                   select((.value.severity == "high" or .value.severity == "critical") and (.value.fixAvailable != false)) |
-                  [.key, (.value.severity | ascii_upcase), (if .value.fixAvailable == true then "auto" else "manual" end)] |
+                  [
+                    .key,
+                    (.value.severity | ascii_upcase),
+                    ($versions[.key] // "unknown"),
+                    (if (.value.fixAvailable | type) == "object" then .value.fixAvailable.version else "" end),
+                    (if .value.fixAvailable == true then "auto" else "manual" end)
+                  ] |
                   @tsv
                 ' "$json_file" 2>/dev/null || echo "")
                 [ -z "$rows" ] && continue
                 found_any=true
                 echo "**\`$scan_dir\`**"
                 echo ""
-                echo "| Package | Severity | Command |"
-                echo "|---------|----------|---------|"
-                while IFS=$'\t' read -r pkg severity fix_type; do
+                echo "| Package | Severity | Installed | Fix ≥ | Command |"
+                echo "|---------|----------|-----------|-------|---------|"
+                while IFS=$'\t' read -r pkg severity installed fix_ver fix_type; do
                   if [ "$fix_type" = "auto" ]; then
-                    echo "| \`$pkg\` | $severity | \`npm audit fix --prefix $scan_dir\` |"
+                    cmd="\`npm audit fix --prefix $scan_dir\`"
                   else
-                    echo "| \`$pkg\` | $severity | \`npm audit fix --force --prefix $scan_dir\` _(may introduce breaking changes)_ |"
+                    cmd="\`npm audit fix --force --prefix $scan_dir\` _(may introduce breaking changes)_"
                   fi
+                  echo "| \`$pkg\` | $severity | \`$installed\` | \`${fix_ver:----}\` | $cmd |"
                 done <<< "$rows"
                 echo ""
               done

--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -298,13 +298,15 @@ jobs:
                 composer --working-dir=${{ inputs.PIMCORE_ROOT }} config --global --auth http-basic.$REPMAN_HOST token "$REPMAN_CLIENT_TOKEN"
               fi
             fi
+            install_ok=true
             if [ ! -f "${{ inputs.PIMCORE_ROOT }}/composer.lock" ]; then
-              composer --working-dir=${{ inputs.PIMCORE_ROOT }} install --prefer-dist --no-scripts --ignore-platform-reqs
+              composer --working-dir=${{ inputs.PIMCORE_ROOT }} install --prefer-dist --no-scripts --ignore-platform-reqs || install_ok=false
             fi
             composer --working-dir=${{ inputs.PIMCORE_ROOT }} audit --abandoned=ignore --locked --no-dev --format=json > /tmp/composer-audit.json 2>/dev/null || true
             composer --working-dir=${{ inputs.PIMCORE_ROOT }} audit --abandoned=ignore --locked --no-dev || true
             jq '[.packages[] | {name, version}]' "${{ inputs.PIMCORE_ROOT }}/composer.lock" > /tmp/composer-packages.json 2>/dev/null || echo '[]' > /tmp/composer-packages.json
-          } 2>&1 | tee /tmp/composer-audit.txt || true
+            [ "$install_ok" = "true" ]
+          } 2>&1 | tee /tmp/composer-audit.txt
           high_critical_count=$(jq '[.advisories // {} | to_entries[] | .value[] | select(.ignored != true and (.severity == "high" or .severity == "critical"))] | length' /tmp/composer-audit.json 2>/dev/null || echo 0)
           [ "$high_critical_count" -eq 0 ]
 

--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -278,35 +278,36 @@ jobs:
         id: composer-scan
         continue-on-error: true
         run: |
+          PIMCORE_ENTERPRISE_TOKEN="${{ secrets.PIMCORE_ENTERPRISE_TOKEN }}"
+          if [[ -z "$PIMCORE_ENTERPRISE_TOKEN" ]]; then
+            PIMCORE_ENTERPRISE_TOKEN=$(printf '%s' '${{ secrets.BUILD_TIME_SECRETS }}' | jq -r '."pimcore-enterprise-token" // empty' 2>/dev/null || true)
+          fi
+          if [[ -n "$PIMCORE_ENTERPRISE_TOKEN" ]]; then
+            echo "::add-mask::$PIMCORE_ENTERPRISE_TOKEN"
+            composer --working-dir=${{ inputs.PIMCORE_ROOT }} config --global --auth http-basic.repo.pimcore.com token "$PIMCORE_ENTERPRISE_TOKEN"
+          fi
+          REPMAN_CLIENT_TOKEN="${{ secrets.REPMAN_CLIENT_TOKEN }}"
+          if [[ -z "$REPMAN_CLIENT_TOKEN" ]]; then
+            REPMAN_CLIENT_TOKEN=$(printf '%s' '${{ secrets.BUILD_TIME_SECRETS }}' | jq -r '."repman-client-token" // empty' 2>/dev/null || true)
+          fi
+          if [[ -n "$REPMAN_CLIENT_TOKEN" ]]; then
+            echo "::add-mask::$REPMAN_CLIENT_TOKEN"
+            REPMAN_HOST=$(jq -r '.repositories // [] | map(select(.url // "" | contains("repman.io"))) | .[0].url // "" | ltrimstr("https://") | ltrimstr("http://") | rtrimstr("/")' ${{ inputs.PIMCORE_ROOT }}/composer.json 2>/dev/null || true)
+            if [[ -n "$REPMAN_HOST" ]]; then
+              composer --working-dir=${{ inputs.PIMCORE_ROOT }} config --global --auth http-basic.$REPMAN_HOST token "$REPMAN_CLIENT_TOKEN"
+            fi
+          fi
+          install_exit=0
+          if [ ! -f "${{ inputs.PIMCORE_ROOT }}/composer.lock" ]; then
+            composer --working-dir=${{ inputs.PIMCORE_ROOT }} install --prefer-dist --no-scripts --ignore-platform-reqs 2>&1 | tee /tmp/composer-install.txt || install_exit=$?
+          fi
           {
-            PIMCORE_ENTERPRISE_TOKEN="${{ secrets.PIMCORE_ENTERPRISE_TOKEN }}"
-            if [[ -z "$PIMCORE_ENTERPRISE_TOKEN" ]]; then
-              PIMCORE_ENTERPRISE_TOKEN=$(printf '%s' '${{ secrets.BUILD_TIME_SECRETS }}' | jq -r '."pimcore-enterprise-token" // empty' 2>/dev/null || true)
-            fi
-            if [[ -n "$PIMCORE_ENTERPRISE_TOKEN" ]]; then
-              echo "::add-mask::$PIMCORE_ENTERPRISE_TOKEN"
-              composer --working-dir=${{ inputs.PIMCORE_ROOT }} config --global --auth http-basic.repo.pimcore.com token "$PIMCORE_ENTERPRISE_TOKEN"
-            fi
-            REPMAN_CLIENT_TOKEN="${{ secrets.REPMAN_CLIENT_TOKEN }}"
-            if [[ -z "$REPMAN_CLIENT_TOKEN" ]]; then
-              REPMAN_CLIENT_TOKEN=$(printf '%s' '${{ secrets.BUILD_TIME_SECRETS }}' | jq -r '."repman-client-token" // empty' 2>/dev/null || true)
-            fi
-            if [[ -n "$REPMAN_CLIENT_TOKEN" ]]; then
-              echo "::add-mask::$REPMAN_CLIENT_TOKEN"
-              REPMAN_HOST=$(jq -r '.repositories // [] | map(select(.url // "" | contains("repman.io"))) | .[0].url // "" | ltrimstr("https://") | ltrimstr("http://") | rtrimstr("/")' ${{ inputs.PIMCORE_ROOT }}/composer.json 2>/dev/null || true)
-              if [[ -n "$REPMAN_HOST" ]]; then
-                composer --working-dir=${{ inputs.PIMCORE_ROOT }} config --global --auth http-basic.$REPMAN_HOST token "$REPMAN_CLIENT_TOKEN"
-              fi
-            fi
-            install_ok=true
-            if [ ! -f "${{ inputs.PIMCORE_ROOT }}/composer.lock" ]; then
-              composer --working-dir=${{ inputs.PIMCORE_ROOT }} install --prefer-dist --no-scripts --ignore-platform-reqs || install_ok=false
-            fi
+            cat /tmp/composer-install.txt 2>/dev/null || true
             composer --working-dir=${{ inputs.PIMCORE_ROOT }} audit --abandoned=ignore --locked --no-dev --format=json > /tmp/composer-audit.json 2>/dev/null || true
             composer --working-dir=${{ inputs.PIMCORE_ROOT }} audit --abandoned=ignore --locked --no-dev || true
             jq '[.packages[] | {name, version}]' "${{ inputs.PIMCORE_ROOT }}/composer.lock" > /tmp/composer-packages.json 2>/dev/null || echo '[]' > /tmp/composer-packages.json
-            [ "$install_ok" = "true" ]
-          } 2>&1 | tee /tmp/composer-audit.txt
+          } 2>&1 | tee /tmp/composer-audit.txt || true
+          [ "$install_exit" -eq 0 ] || exit 1
           high_critical_count=$(jq '[.advisories // {} | to_entries[] | .value[] | select(.ignored != true and (.severity == "high" or .severity == "critical"))] | length' /tmp/composer-audit.json 2>/dev/null || echo 0)
           [ "$high_critical_count" -eq 0 ]
 

--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -317,6 +317,7 @@ jobs:
             --config p/github-actions \
             --config p/typescript \
             --error \
+            --json-output /tmp/semgrep.json \
             . 2>&1 | tee /tmp/semgrep.txt
           exit ${PIPESTATUS[0]}
         env:
@@ -332,6 +333,7 @@ jobs:
           cp /tmp/composer-audit.json scan-results/ 2>/dev/null || true
           cp /tmp/composer-packages.json scan-results/ 2>/dev/null || true
           cp /tmp/semgrep.txt scan-results/ 2>/dev/null || true
+          cp /tmp/semgrep.json scan-results/ 2>/dev/null || true
 
       - name: Upload scan results artifact
         if: always()

--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -299,7 +299,11 @@ jobs:
           fi
           install_exit=0
           if [ ! -f "${{ inputs.PIMCORE_ROOT }}/composer.lock" ]; then
-            composer --working-dir=${{ inputs.PIMCORE_ROOT }} install --prefer-dist --no-scripts --ignore-platform-reqs 2>&1 | tee /tmp/composer-install.txt || install_exit=$?
+            set +e
+            composer --working-dir=${{ inputs.PIMCORE_ROOT }} install --prefer-dist --no-scripts --ignore-platform-reqs > /tmp/composer-install.txt 2>&1
+            install_exit=$?
+            set -e
+            cat /tmp/composer-install.txt
           fi
           {
             cat /tmp/composer-install.txt 2>/dev/null || true

--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -301,6 +301,7 @@ jobs:
             fi
             composer --working-dir=${{ inputs.PIMCORE_ROOT }} audit --abandoned=ignore --locked --no-dev --format=json > /tmp/composer-audit.json 2>/dev/null || true
             composer --working-dir=${{ inputs.PIMCORE_ROOT }} audit --abandoned=ignore --locked --no-dev || true
+            jq '[.packages[] | {name, version}]' "${{ inputs.PIMCORE_ROOT }}/composer.lock" > /tmp/composer-packages.json 2>/dev/null || echo '[]' > /tmp/composer-packages.json
           } 2>&1 | tee /tmp/composer-audit.txt || true
           high_critical_count=$(jq '[.advisories // {} | to_entries[] | .value[] | select(.ignored != true and (.severity == "high" or .severity == "critical"))] | length' /tmp/composer-audit.json 2>/dev/null || echo 0)
           [ "$high_critical_count" -eq 0 ]
@@ -329,6 +330,7 @@ jobs:
           cp /tmp/npm-raw-*.json scan-results/ 2>/dev/null || true
           cp /tmp/composer-audit.txt scan-results/ 2>/dev/null || true
           cp /tmp/composer-audit.json scan-results/ 2>/dev/null || true
+          cp /tmp/composer-packages.json scan-results/ 2>/dev/null || true
           cp /tmp/semgrep.txt scan-results/ 2>/dev/null || true
 
       - name: Upload scan results artifact

--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -263,6 +263,8 @@ jobs:
             npm audit --json --omit=dev --prefix "$dir" 2>/dev/null \
               | jq --arg dir "$dir" '. + {_scannedDir: $dir}' \
               > "/tmp/npm-raw-${dir_slug:-root}.json" || true
+            jq '[.packages // {} | to_entries[] | select(.key | test("^node_modules/(@[^/]+/[^/]+|[^/]+)$")) | {name: (.key | ltrimstr("node_modules/")), version: .value.version}]' \
+              "$dir/package-lock.json" > "/tmp/npm-packages-${dir_slug:-root}.json" 2>/dev/null || echo '[]' > "/tmp/npm-packages-${dir_slug:-root}.json"
             fixable_count=$(jq '[(.vulnerabilities // {}) | to_entries[] | select((.value.severity == "high" or .value.severity == "critical") and .value.fixAvailable == true)] | length' "/tmp/npm-raw-${dir_slug:-root}.json" 2>/dev/null || echo 0)
             if [ "$fixable_count" -gt 0 ]; then
               result=1
@@ -329,6 +331,7 @@ jobs:
           mkdir -p scan-results
           cp /tmp/npm-audit.txt scan-results/ 2>/dev/null || true
           cp /tmp/npm-raw-*.json scan-results/ 2>/dev/null || true
+          cp /tmp/npm-packages-*.json scan-results/ 2>/dev/null || true
           cp /tmp/composer-audit.txt scan-results/ 2>/dev/null || true
           cp /tmp/composer-audit.json scan-results/ 2>/dev/null || true
           cp /tmp/composer-packages.json scan-results/ 2>/dev/null || true


### PR DESCRIPTION
- Fixes occasional crashing of post-scan-results job
- Fixes incorrect assertion that `npm audit fix --force` was needed for non-major ugprades
- Now properly includes affected version, fixed version, and advisory information for Composer and npm results